### PR TITLE
Fix tick counting for processes

### DIFF
--- a/include/proc.h
+++ b/include/proc.h
@@ -104,10 +104,3 @@ struct proc {
 //   original data and bss
 //   fixed-size stack
 //   expandable heap
-
-struct ptable_type {
-  struct spinlock lock;
-  struct proc proc[NPROC];
-}; 
-
-extern struct ptable_type ptable;

--- a/kernel/proc.c
+++ b/kernel/proc.c
@@ -47,6 +47,7 @@ allocproc(void)
 found:
   p->state = EMBRYO;
   p->pid = nextpid++;
+  p->ticks = 0;
   release(&ptable.lock);
 
   // Allocate kernel stack.
@@ -285,11 +286,8 @@ scheduler(void)
       switchuvm(p);
       p->state = RUNNING;
       p->inuse = 1;
-      const int tickstart = ticks;
-      
+
       swtch(&cpu->scheduler, proc->context);
-    
-      p->ticks += ticks - tickstart;
     
       switchkvm();
       // Process is done running for now.

--- a/kernel/proc.c
+++ b/kernel/proc.c
@@ -7,7 +7,10 @@
 #include "proc.h"
 #include "spinlock.h"
 
-struct ptable_type ptable; /* initialize process table */
+struct {
+  struct spinlock lock;
+  struct proc proc[NPROC];
+} ptable;
 
 static struct proc *initproc;
 

--- a/kernel/sysproc.c
+++ b/kernel/sysproc.c
@@ -6,6 +6,11 @@
 #include "mmu.h"
 #include "proc.h"
 
+extern struct {
+  struct spinlock lock;
+  struct proc proc[NPROC];
+} ptable;
+
 int
 sys_fork(void)
 {

--- a/kernel/trap.c
+++ b/kernel/trap.c
@@ -53,6 +53,8 @@ trap(struct trapframe *tf)
     if(cpu->id == 0){
       acquire(&tickslock);
       ticks++;
+      if (proc != 0)
+          proc->ticks++;
       wakeup(&ticks);
       release(&tickslock);
     }


### PR DESCRIPTION
- Move ptable definition back to proc.c.
- Process' ticks should be updated at each timer IRQ and not at each context switch.
- When allocating a new process, ticks should reset for that process.