### PR TITLE
Fix tick counting for processes

### DIFF
--- a/include/proc.h
+++ b/include/proc.h
@@ -105,9 +105,7 @@ struct proc {
 //   fixed-size stack
 //   expandable heap
 
-struct ptable_type {
+struct ptable {
   struct spinlock lock;
   struct proc proc[NPROC];
-}; 
-
-extern struct ptable_type ptable;
+};

--- a/kernel/proc.c
+++ b/kernel/proc.c
@@ -44,6 +44,7 @@ allocproc(void)
 found:
   p->state = EMBRYO;
   p->pid = nextpid++;
+  p->ticks = 0;
   release(&ptable.lock);
 
   // Allocate kernel stack.
@@ -282,11 +283,8 @@ scheduler(void)
       switchuvm(p);
       p->state = RUNNING;
       p->inuse = 1;
-      const int tickstart = ticks;
-      
+
       swtch(&cpu->scheduler, proc->context);
-    
-      p->ticks += ticks - tickstart;
     
       switchkvm();
       // Process is done running for now.

--- a/kernel/proc.c
+++ b/kernel/proc.c
@@ -7,7 +7,7 @@
 #include "proc.h"
 #include "spinlock.h"
 
-struct ptable_type ptable; /* initialize process table */
+struct ptable ptable;
 
 static struct proc *initproc;
 

--- a/kernel/sysproc.c
+++ b/kernel/sysproc.c
@@ -6,6 +6,8 @@
 #include "mmu.h"
 #include "proc.h"
 
+extern struct ptable ptable;
+
 int
 sys_fork(void)
 {

--- a/kernel/trap.c
+++ b/kernel/trap.c
@@ -53,8 +53,9 @@ trap(struct trapframe *tf)
     if(cpu->id == 0){
       acquire(&tickslock);
       ticks++;
-      if (proc != 0)
+      if (proc && (tf->cs & 3) == 3) {
           proc->ticks++;
+      }
       wakeup(&ticks);
       release(&tickslock);
     }

--- a/kernel/trap.c
+++ b/kernel/trap.c
@@ -53,6 +53,8 @@ trap(struct trapframe *tf)
     if(cpu->id == 0){
       acquire(&tickslock);
       ticks++;
+      if (proc != 0)
+          proc->ticks++;
       wakeup(&ticks);
       release(&tickslock);
     }


### PR DESCRIPTION
- clean table definition and declarations
- counting ticks for processes should be done at each timer IRQ and not at each context switch
- process ticks are ticks that occurred when the process was running in user space